### PR TITLE
 use proxy defined in HTTP_PROXY environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
         npx jasmine spec/*.mjs
     - name: run test CJS
       run: |
-        npm run updatedb-cjs
+        npm run cjs
         npx jasmine spec/*.cjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 20, 14, 24, 16, 18]
+        node-version: [16, 18, 20, 22, 24]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ ILA_TMP_DATA_DIR=/your_tmporary_directory_for_database
 
 ## Node.js version
 
-This library supports Node.js >= 14 for ESM and CJS.
+This library supports Node.js >= 16 for ESM and CJS.
 
 
 ## License and EULA

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "Multiple licenses",
   "type": "module",
   "engines": {
-    "node": ">=14.8.0"
+    "node": ">=16.0.0"
   },
   "main": "cjs/main.cjs",
   "types": "types/cjs/main.d.cts",

--- a/package.json
+++ b/package.json
@@ -103,12 +103,12 @@
     "README.md"
   ],
   "dependencies": {
-    "axios": "^1.8.4",
     "countries-list": "^3.1.1",
     "cron": "^3.1.7",
     "dayjs": "^1.11.13",
     "fast-csv": "^5.0.1",
     "ip-address": "^9.0.5",
+    "undici": "^5.29.0",
     "yauzl": "^3.1.3"
   },
   "devDependencies": {

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -1,11 +1,11 @@
 import fs from 'fs/promises'
 import fsSync from 'fs'
 import path from 'path'
+import { fetch, request } from 'undici'
 import { fileURLToPath } from 'url'
 import { createHash } from 'crypto'
 import { pipeline } from 'stream/promises'
 
-import axios from 'axios'
 import { parse } from '@fast-csv/parse'
 import { Address4, Address6 } from 'ip-address'
 import dayjs from 'dayjs'
@@ -105,16 +105,12 @@ const ipLocationDb = async (db) => {
 
 const _ipLocationDb = async (url) => {
 	var fileEnd = url.split('-').pop()
-	return axios({
-		method: 'get',
-		url: url,
-		responseType: 'stream'
-	}).then(res => {
+	return request(url).then(res => {
 		return new Promise((resolve, reject) => {
 			var fileName = setting.ipLocationDb + '-Blocks-' + fileEnd
 			const ws = fsSync.createWriteStream(path.join(setting.tmpDataDir, fileName))
 			ws.write('network1,network2,cc\n')
-			res.data.pipe(ws)
+			res.body.pipe(ws)
 			ws.on('finish', () => {
 				resolve(fileName)
 			})
@@ -296,8 +292,8 @@ const downloadZip = async () => {
 		url = 'https://raw.githubusercontent.com/sapics/node-geolite2-redist/master/redist/'
 		url += database.edition + '.' + database.suffix
 	}
-	var text = await axios.get(url)
-	var reg = /\w{50,}/, r = reg.exec(text.data)
+	var text = await (await request(url)).body.text()
+	var reg = /\w{50,}/, r = reg.exec(text)
 	if(!r) {
 		return consoleWarn('Cannot download sha256')
 	}
@@ -329,16 +325,12 @@ const downloadZip = async () => {
 		url = 'https://raw.githubusercontent.com/sapics/node-geolite2-redist/master/redist/'
 		url += database.edition + '.' + database.suffix.replace('.sha256', '')
 	}
-	return axios({
-		method: 'get',
-		url: url,
-		responseType: 'stream'
-	}).then(res => {
+	return request(url).then(res => {
 		const dest = fsSync.createWriteStream(zipPath)
 		return new Promise((resolve, reject) => {
 			consoleLog('Decompressing', database.edition + '.zip')
-			res.data.pipe(dest)
-			res.data.on('end', () => {
+			res.body.pipe(dest)
+			res.body.on('end', () => {
 				yauzl.open(zipPath, {lazyEntries: true}, (err, zipfile) => {
 					if(err) return reject(err)
 					zipfile.readEntry()
@@ -361,7 +353,7 @@ const downloadZip = async () => {
 					zipfile.on('end', () => resolve(database.src))
 				})
 			})
-			res.data.on('error', reject)
+			res.body.on('error', reject)
 		})
 	})
 }


### PR DESCRIPTION
This PR deletes axios ( prolonging PR #29 ) and uses https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md to use a proxy according to what is defined in the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.

PS: I haven't updated https://github.com/sapics/ip-location-api/tree/main/cjs

Possible improvement to avoid a potential breaking change: add a setting like ILA_ENV_HTTP_PROXY to specify whether to use the EnvHttpProxyAgent dispatcher, or the default one.